### PR TITLE
Fix the getStats information

### DIFF
--- a/moadmin.php
+++ b/moadmin.php
@@ -135,6 +135,20 @@ class get {
                                        : htmlentities($string, $quoteStyle, $charset));
     }
 
+	/** 
+	 * Generates a HTML nested list from an array by recursive traversal.
+	 */
+	public function array_to_list($array){
+    	foreach( $array as $k => $v ){
+        	if( is_array( $v ) ){
+            	$out .= '<li>' . $k . ': <ul>' . self::array_to_list( $v ).'</ul></li>';
+        	} else {
+            	$out .= '<li>' . $k . ': ' . $v . '</li>';
+        	}
+    	}
+    	return $out;
+	}
+
     /**
      * Initialize the character maps needed for the xhtmlentities() method and verifies the argument values
      * passed to it are valid.
@@ -2583,20 +2597,9 @@ mo.submitQuery = function() {
 ' . $dbcollnavJs);
 } else if (isset($mo->mongo['getStats'])) {
     echo '<ul>';
-    foreach ($mo->mongo['getStats'] as $key => $val) {
-        echo '<li>';
-        if (!is_array($val)) {
-            echo $key . ': ' . $val;
-        } else {
-            echo $key . '<ul>';
-            foreach ($val as $subkey => $subval) {
-                echo $html->li($subkey . ': ' . $subval);
-            }
-            echo '</ul>';
-        }
-        echo '</li>';
-    }
+    echo get::array_to_list( $mo->mongo['getStats'] );
     echo '</ul>';
+
 }
 echo '</div>'; //end of bodycontent
 


### PR DESCRIPTION
Some of the statistics on the getStats page would return Array and not traverse correctly.  This is because of the information being further nested in an array.  In order to display all the statistics, I have added a recursive array traversal method which returns a well formatted HTML list.
